### PR TITLE
Update Aparapi package name

### DIFF
--- a/nn-core/src/main/java/com/github/neuralnetworks/architecture/NeuralNetworkImpl.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/architecture/NeuralNetworkImpl.java
@@ -137,7 +137,7 @@ public class NeuralNetworkImpl implements NeuralNetwork {
 	    if (layers != null) {
 		// remove layer and bias layers
 		layers.remove(layer);
-		layer.getConnections(this).stream().map(Connections::getInputLayer).filter(l -> Util.isBias(l)).forEach(l -> layers.remove(l));
+		layer.getConnections(this).stream().map(Connections::getInputLayer).filter(Util::isBias).forEach(l -> layers.remove(l));
 	    }
 	}
     }
@@ -161,7 +161,7 @@ public class NeuralNetworkImpl implements NeuralNetwork {
      * Add connection to the network - this means adding both input and output
      * layers to the network
      * 
-     * @param connection
+     * @param connections
      */
     public void addConnections(Connections... connections) {
 	if (connections != null) {

--- a/nn-core/src/main/java/com/github/neuralnetworks/architecture/types/Autoencoder.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/architecture/types/Autoencoder.java
@@ -17,12 +17,12 @@ public class Autoencoder extends NeuralNetworkImpl {
 
     public Layer getHiddenBiasLayer() {
 	Layer hiddenLayer = getHiddenLayer();
-	return hiddenLayer.getConnections().stream().map(c -> Util.getOppositeLayer(c, hiddenLayer)).filter(l -> Util.isBias(l)).findFirst().orElse(null);
+	return hiddenLayer.getConnections().stream().map(c -> Util.getOppositeLayer(c, hiddenLayer)).filter(Util::isBias).findFirst().orElse(null);
     }
 
     public Layer getOutputBiasLayer() {
 	Layer outputLayer = getOutputLayer();
-	return outputLayer.getConnections().stream().map(c -> Util.getOppositeLayer(c, outputLayer)).filter(l -> Util.isBias(l)).findFirst().orElse(null);
+	return outputLayer.getConnections().stream().map(c -> Util.getOppositeLayer(c, outputLayer)).filter(Util::isBias).findFirst().orElse(null);
     }
 
     public Layer getHiddenLayer() {

--- a/nn-core/src/main/java/com/github/neuralnetworks/architecture/types/NNFactory.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/architecture/types/NNFactory.java
@@ -43,9 +43,9 @@ public class NNFactory {
      * Convolutional connections must have 4 parameters - kernelRows, kernelColumns, filters and stride. The first layer must be convolutional.
      * Subsampling connections must have 2 parameters - subsamplingRegionRows, subsamplingRegionCols
      * Regular layers must have 1 parameter - neuron count
-     * 
+     *
+	 * @param layers
      * @param addBias
-     * @param useSharedMemory - whether all network weights should be in a single array
      * @return neural network
      */
     public static NeuralNetworkImpl convNN(int[][] layers, boolean addBias) {
@@ -132,7 +132,6 @@ public class NNFactory {
      * Multi layer perceptron with fully connected layers
      * @param layers - neuron count for each layer
      * @param addBias
-     * @param useSharedMemory - whether all network weights will be part of single array
      * @return
      */
     public static NeuralNetworkImpl mlp(int[] layers, boolean addBias) {
@@ -299,7 +298,7 @@ public class NNFactory {
     public static void lcMaxPooling(NeuralNetworkImpl nn) {
 	if (nn.getLayerCalculator() instanceof LayerCalculatorImpl) {
 	    LayerCalculatorImpl lc = (LayerCalculatorImpl) nn.getLayerCalculator();
-	    nn.getLayers().stream().filter(l -> Util.isSubsampling(l)).forEach(l -> lc.addConnectionCalculator(l, new AparapiMaxPooling2D()));
+	    nn.getLayers().stream().filter(Util::isSubsampling).forEach(l -> lc.addConnectionCalculator(l, new AparapiMaxPooling2D()));
 	} else {
 	    throw new IllegalArgumentException("LayerCalculator type not supported");
 	}
@@ -308,7 +307,7 @@ public class NNFactory {
     public static void lcAveragePooling(NeuralNetworkImpl nn) {
 	if (nn.getLayerCalculator() instanceof LayerCalculatorImpl) {
 	    LayerCalculatorImpl lc = (LayerCalculatorImpl) nn.getLayerCalculator();
-	    nn.getLayers().stream().filter(l -> Util.isSubsampling(l)).forEach(l -> lc.addConnectionCalculator(l, new AparapiAveragePooling2D()));
+	    nn.getLayers().stream().filter(Util::isSubsampling).forEach(l -> lc.addConnectionCalculator(l, new AparapiAveragePooling2D()));
 	} else {
 	    throw new IllegalArgumentException("LayerCalculator type not supported");
 	}
@@ -317,7 +316,7 @@ public class NNFactory {
     public static void lcStochasticPooling(NeuralNetworkImpl nn) {
 	if (nn.getLayerCalculator() instanceof LayerCalculatorImpl) {
 	    LayerCalculatorImpl lc = (LayerCalculatorImpl) nn.getLayerCalculator();
-	    nn.getLayers().stream().filter(l -> Util.isSubsampling(l)).forEach(l -> lc.addConnectionCalculator(l, new AparapiStochasticPooling2D()));
+	    nn.getLayers().stream().filter(Util::isSubsampling).forEach(l -> lc.addConnectionCalculator(l, new AparapiStochasticPooling2D()));
 	} else {
 	    throw new IllegalArgumentException("LayerCalculator type not supported");
 	}
@@ -350,9 +349,7 @@ public class NNFactory {
     public static NeuralNetworkImpl maxout(int[] layers, boolean addBias, ConnectionCalculator outputCC) {
 	NeuralNetworkImpl result = mlp(layers, addBias);
 	result.setLayerCalculator(lcMaxout(result, outputCC));
-	result.getConnections().stream().filter(c -> c instanceof FullyConnected).forEach(c -> {
-	    MaxoutWinners.getInstance().addConnections(c);
-	});
+	result.getConnections().stream().filter(c -> c instanceof FullyConnected).forEach(c -> MaxoutWinners.getInstance().addConnections(c));
 
 	return result;
     }
@@ -536,6 +533,6 @@ public class NNFactory {
     }
 
     public static void populateBiasLayers(LayerCalculatorImpl lc, NeuralNetwork nn) {
-	nn.getLayers().stream().filter(l -> Util.isBias(l)).forEach(l -> lc.addConnectionCalculator(l, new ConstantConnectionCalculator()));
+	nn.getLayers().stream().filter(Util::isBias).forEach(l -> lc.addConnectionCalculator(l, new ConstantConnectionCalculator()));
     }
 }

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/LayerCalculator.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/LayerCalculator.java
@@ -21,14 +21,8 @@ public interface LayerCalculator extends Serializable {
      *            - existing results
      * @param layer
      *            - the layer to be calculated
-     */
-    /**
-     * @param calculatedLayers
-     *            - calculated layers that are provided as input
      * @param results
      *            - where the results are stored
-     * @param layer
-     *            - current layer
      * @param neuralNetwork
      *            - the network of context for calculation
      */

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/memory/ValuesProvider.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/memory/ValuesProvider.java
@@ -42,8 +42,8 @@ public class ValuesProvider implements Serializable {
     /**
      * Get values for object based on provided dimensions
      * 
-     * @param targetLayer
-     * @param unitCount
+     * @param key
+     * @param dimensions
      * @return
      */
     @SuppressWarnings("unchecked")
@@ -81,12 +81,9 @@ public class ValuesProvider implements Serializable {
      * @param dimensions
      */
     public void add(Object key, boolean useSharedMemory, int... dimensions) {
-	List<Tensor> set = values.get(key);
-	if (set == null) {
-	    values.put(key, set = new UniqueList<Tensor>());
-	}
+		List<Tensor> set = values.computeIfAbsent(key, k -> new UniqueList<Tensor>());
 
-	int size = Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
+		int size = Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
 	float[] elements = null;
 	int offset = 0;
 

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiConv2D.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiConv2D.java
@@ -3,7 +3,7 @@ package com.github.neuralnetworks.calculation.neuronfunctions;
 import java.io.Serializable;
 import java.util.Arrays;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.architecture.Conv2DConnection;
 import com.github.neuralnetworks.architecture.Layer;
 import com.github.neuralnetworks.calculation.memory.ValuesProvider;

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiFullyConnected.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiFullyConnected.java
@@ -3,7 +3,7 @@ package com.github.neuralnetworks.calculation.neuronfunctions;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.architecture.Connections;
 import com.github.neuralnetworks.architecture.FullyConnected;
 import com.github.neuralnetworks.architecture.Layer;

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiFullyConnected.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiFullyConnected.java
@@ -167,7 +167,7 @@ public abstract class AparapiFullyConnected extends Kernel implements Connection
 	    return false;
 	}
 
-	if (connections.stream().filter(c -> TensorFactory.tensor(Util.getOppositeLayer(c, targetLayer), c, valuesProvider).getElements() != input).findAny().isPresent()) {
+	if (connections.stream().anyMatch(c -> TensorFactory.tensor(Util.getOppositeLayer(c, targetLayer), c, valuesProvider).getElements() != input)) {
 	    return false;
 	}
 

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiSubsampling2D.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/AparapiSubsampling2D.java
@@ -2,7 +2,7 @@ package com.github.neuralnetworks.calculation.neuronfunctions;
 
 import java.util.List;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.architecture.Connections;
 import com.github.neuralnetworks.architecture.Layer;
 import com.github.neuralnetworks.architecture.Subsampling2DConnection;
@@ -137,7 +137,7 @@ public abstract class AparapiSubsampling2D extends Kernel implements ConnectionC
     }
 
     /* (non-Javadoc)
-     * @see com.amd.aparapi.Kernel#run()
+     * @see com.aparapi.Kernel#run()
      * input start index is calculated and passed to the pooling method
      */
     @Override

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/BernoulliDistribution.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/BernoulliDistribution.java
@@ -18,12 +18,9 @@ public class BernoulliDistribution implements TensorFunction {
 
     @Override
     public void value(Tensor inputOutput) {
-	BernoulliKernel kernel = kernels.get(inputOutput.getElements().length);
-	if (kernel == null) {
-	    kernels.put(inputOutput.getElements().length, kernel = new BernoulliKernel(inputOutput.getElements().length));
-	}
+		BernoulliKernel kernel = kernels.computeIfAbsent(inputOutput.getElements().length, k -> new BernoulliKernel(inputOutput.getElements().length));
 
-	kernel.values = inputOutput.getElements();
+		kernel.values = inputOutput.getElements();
 
 	Environment.getInstance().getExecutionStrategy().execute(kernel, inputOutput.getElements().length);
     }

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/ConnectionCalculatorFullyConnected.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/ConnectionCalculatorFullyConnected.java
@@ -183,9 +183,7 @@ public class ConnectionCalculatorFullyConnected implements ConnectionCalculator,
     }
 
     private ConnectionCalculator getConnectionCalculator(List<Connections> connections, ValuesProvider valuesProvider, Layer targetLayer) {
-	ConnectionCalculator result = inputFunctions.stream().filter(c -> {
-	    return !(c instanceof AparapiFullyConnected) || ((AparapiFullyConnected) c).accept(connections, valuesProvider, targetLayer);
-	}).findFirst().orElse(createInputFunction(connections, valuesProvider, targetLayer));
+	ConnectionCalculator result = inputFunctions.stream().filter(c -> !(c instanceof AparapiFullyConnected) || ((AparapiFullyConnected) c).accept(connections, valuesProvider, targetLayer)).findFirst().orElse(createInputFunction(connections, valuesProvider, targetLayer));
 	inputFunctions.add(result);
 
 	return result;

--- a/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/SoftmaxFunction.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/calculation/neuronfunctions/SoftmaxFunction.java
@@ -1,6 +1,6 @@
 package com.github.neuralnetworks.calculation.neuronfunctions;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.tensor.Matrix;
 import com.github.neuralnetworks.tensor.Tensor;
 import com.github.neuralnetworks.util.Environment;

--- a/nn-core/src/main/java/com/github/neuralnetworks/tensor/Tensor.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/tensor/Tensor.java
@@ -65,7 +65,7 @@ public class Tensor implements Serializable {
 	    }
 	}
 
-	size = IntStream.range(0, dimensions.length).map(i -> dimensions[i]).reduce(1, (a, b) -> a * b);
+	size = Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
     }
 
     public Tensor(int startOffset, float[] elements, int[] globalDimensions, int[][] globalDimensionsLimit) {
@@ -95,7 +95,7 @@ public class Tensor implements Serializable {
 	    Arrays.stream(dimensions).skip(i + 1).limit(dimensions.length).forEach(j -> dimMultiplicators[i] *= j);
 	});
 
-	size = IntStream.range(0, dimensions.length).map(i -> dimensions[i]).reduce(1, (a, b) -> a * b);
+	size = Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
     }
 
     public float get(int... d) {

--- a/nn-core/src/main/java/com/github/neuralnetworks/tensor/TensorFactory.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/tensor/TensorFactory.java
@@ -82,9 +82,7 @@ public class TensorFactory {
      */
     public static Tensor[] tensor(int[]... dimensions) {
 	Tensor[] result = new Tensor[dimensions.length];
-	float[] elements = new float[Arrays.stream(dimensions).map(d -> {
-	    return IntStream.of(d).reduce(1, (a, b) -> a * b);
-	}).reduce(0, (a, b) -> a + b)];
+	float[] elements = new float[Arrays.stream(dimensions).map(d -> IntStream.of(d).reduce(1, (a, b) -> a * b)).reduce(0, (a, b) -> a + b)];
 
 	for (int i = 0, offset = 0; i < dimensions.length; i++) {
 	    int[] d = dimensions[i];
@@ -109,9 +107,7 @@ public class TensorFactory {
      */
     public static Matrix matrix(float[][] elements) {
 	Matrix result = tensor(elements[0].length, elements.length);
-	IntStream.range(0, elements.length).forEach(i -> IntStream.range(0, elements[i].length).forEach(j -> {
-	    result.set(elements[i][j], j, i);
-	}));
+	IntStream.range(0, elements.length).forEach(i -> IntStream.range(0, elements[i].length).forEach(j -> result.set(elements[i][j], j, i)));
 
 	return result;
     }
@@ -140,12 +136,11 @@ public class TensorFactory {
 
 	// create tensors
 	List<Layer> layers = new ArrayList<>(dims.keySet());
-	for (int i = 0; i < layers.size(); i++) {
-	    Layer l = layers.get(i);
-	    for (int[] d : dims.get(l)) {
-		result.add(l, true, d);
-	    }
-	}
+		for (Layer l : layers) {
+			for (int[] d : dims.get(l)) {
+				result.add(l, true, d);
+			}
+		}
 
 	return result;
     }
@@ -164,14 +159,13 @@ public class TensorFactory {
 	    
 	    // create tensors
 	    List<Layer> layers = new ArrayList<>(dims.keySet());
-	    for (int i = 0; i < layers.size(); i++) {
-		Layer l = layers.get(i);
-		for (int[] d : dims.get(l)) {
-		    if (result.get(l, d) == null) {
-			result.add(l, true, d);
-		    }
+		for (Layer l : layers) {
+			for (int[] d : dims.get(l)) {
+				if (result.get(l, d) == null) {
+					result.add(l, true, d);
+				}
+			}
 		}
-	    }
 	}
 
 	return result;
@@ -189,12 +183,11 @@ public class TensorFactory {
 
 	// create tensors
 	List<Layer> layers = new ArrayList<>(dims.keySet());
-	for (int i = 0; i < layers.size(); i++) {
-	    Layer l = layers.get(i);
-	    for (int[] d : dims.get(l)) {
-		result.add(l, true, d);
-	    }
-	}
+		for (Layer l : layers) {
+			for (int[] d : dims.get(l)) {
+				result.add(l, true, d);
+			}
+		}
 	
 	return result;
     }
@@ -291,47 +284,41 @@ public class TensorFactory {
 	Map<Layer, Set<int[]>> result = new HashMap<>();
 
 	for (Connections c : neuralNetwork.getConnections()) {
-	    Set<int[]> din = result.get(c.getInputLayer());
-	    if (din == null) {
-		result.put(c.getInputLayer(), din = new HashSet<>());
-	    }
+		Set<int[]> din = result.computeIfAbsent(c.getInputLayer(), k -> new HashSet<>());
 
-	    Set<int[]> dout = result.get(c.getOutputLayer());
-	    if (dout == null) {
-		result.put(c.getOutputLayer(), dout = new HashSet<>());
-	    }
+		Set<int[]> dout = result.computeIfAbsent(c.getOutputLayer(), k -> new HashSet<>());
 
-	    if (c instanceof FullyConnected) {
+		if (c instanceof FullyConnected) {
 		FullyConnected fc = (FullyConnected) c;
 		int[] inputDim = new int[] { fc.getInputUnitCount(), miniBatchSize };
 		int[] outputDim = new int[] { fc.getOutputUnitCount(), miniBatchSize };
 		inputDim[0] = fc.getInputUnitCount();
 		outputDim[0] = fc.getOutputUnitCount();
 
-		if (!din.stream().anyMatch(i -> Arrays.equals(i, inputDim))) {
+		if (din.stream().noneMatch(i -> Arrays.equals(i, inputDim))) {
 		    din.add(inputDim);
 		}
-		if (!dout.stream().anyMatch(i -> Arrays.equals(i, outputDim))) {
+		if (dout.stream().noneMatch(i -> Arrays.equals(i, outputDim))) {
 		    dout.add(outputDim);
 		}
 	    } else if (c instanceof Conv2DConnection) {
 		Conv2DConnection cc = (Conv2DConnection) c;
 		int[] inputDim = new int[] { cc.getInputFilters(), cc.getInputFeatureMapRows(), cc.getInputFeatureMapColumns(), miniBatchSize };
 		int[] outputDim = new int[] { cc.getOutputFilters(), cc.getOutputFeatureMapRows(), cc.getOutputFeatureMapColumns(), miniBatchSize };
-		if (!din.stream().anyMatch(i -> Arrays.equals(i, inputDim))) {
+		if (din.stream().noneMatch(i -> Arrays.equals(i, inputDim))) {
 		    din.add(inputDim);
 		}
-		if (!dout.stream().anyMatch(i -> Arrays.equals(i, outputDim))) {
+		if (dout.stream().noneMatch(i -> Arrays.equals(i, outputDim))) {
 		    dout.add(outputDim);
 		}
 	    } else if (c instanceof Subsampling2DConnection) {
 		Subsampling2DConnection cc = (Subsampling2DConnection) c;
 		int[] inputDim = new int[] { cc.getFilters(), cc.getInputFeatureMapRows(), cc.getInputFeatureMapColumns(), miniBatchSize };
 		int[] outputDim = new int[] { cc.getFilters(), cc.getOutputFeatureMapRows(), cc.getOutputFeatureMapColumns(), miniBatchSize };
-		if (!din.stream().anyMatch(i -> Arrays.equals(i, inputDim))) {
+		if (din.stream().noneMatch(i -> Arrays.equals(i, inputDim))) {
 		    din.add(inputDim);
 		}
-		if (!dout.stream().anyMatch(i -> Arrays.equals(i, outputDim))) {
+		if (dout.stream().noneMatch(i -> Arrays.equals(i, outputDim))) {
 		    dout.add(outputDim);
 		}
 	    }

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/random/AparapiXORShiftInitializer.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/random/AparapiXORShiftInitializer.java
@@ -30,12 +30,9 @@ public class AparapiXORShiftInitializer implements RandomInitializer {
     public void initialize(Tensor t) {
 	float[] array = t.getElements();
 
-	XORShift kernel = kernels.get(array.length);
-	if (kernel == null) {
-	    kernels.put(array.length, kernel = new XORShift(array.length, start, range, t.getStartIndex()));
-	}
+		XORShift kernel = kernels.computeIfAbsent(array.length, k -> new XORShift(array.length, start, range, t.getStartIndex()));
 
-	kernel.array = array;
+		kernel.array = array;
 
 	Environment.getInstance().getExecutionStrategy().execute(kernel, t.getSize());
     }

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/random/PRNGKernel.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/random/PRNGKernel.java
@@ -1,6 +1,6 @@
 package com.github.neuralnetworks.training.random;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 
 /**
  * Pseudo Random Number Generator Kernel

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/random/XORShiftKernel.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/random/XORShiftKernel.java
@@ -3,7 +3,7 @@ package com.github.neuralnetworks.training.random;
 import org.uncommons.maths.binary.BinaryUtils;
 import org.uncommons.maths.random.DefaultSeedGenerator;
 
-import com.amd.aparapi.Range;
+import com.aparapi.Range;
 
 /**
  * PRNG implementing XORShiftRNG from Uncommons Maths library (

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/random/XORShiftKernel.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/random/XORShiftKernel.java
@@ -49,8 +49,7 @@ public abstract class XORShiftKernel extends PRNGKernel {
 	if (SEED_SIZE * maxThreads != seeds.length)
 	    throw new IllegalArgumentException(String.format("Wrong size of seeds for threads! Expected %d, got %d, for %d threads.", SEED_SIZE * maxThreads, seeds.length, maxThreads));
 
-	for (int n = 0; n < states.length; n++)
-	    states[n] = seeds[n];
+		System.arraycopy(seeds, 0, states, 0, states.length);
     }
 
     /**

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDBiasUpdatesKernel.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDBiasUpdatesKernel.java
@@ -2,7 +2,7 @@ package com.github.neuralnetworks.training.rbm;
 
 import java.io.Serializable;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.tensor.Matrix;
 
 /**

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDTrainerBase.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDTrainerBase.java
@@ -35,7 +35,7 @@ public abstract class CDTrainerBase extends OneStepTrainer<RBM> {
     protected void learnInput(int batch) {
 	RBM nn = getNeuralNetwork();
 
-	getLayerCalculator().gibbsSampling(nn, getGibbsSamplingCount(), batch == 0 ? true : !getIsPersistent());
+	getLayerCalculator().gibbsSampling(nn, getGibbsSamplingCount(), batch == 0 || !getIsPersistent());
 
 	// update weights
 	updateWeights();

--- a/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDWeightUpdatesKernel.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/training/rbm/CDWeightUpdatesKernel.java
@@ -2,7 +2,7 @@ package com.github.neuralnetworks.training.rbm;
 
 import java.io.Serializable;
 
-import com.amd.aparapi.Kernel;
+import com.aparapi.Kernel;
 import com.github.neuralnetworks.tensor.Matrix;
 
 /**

--- a/nn-core/src/main/java/com/github/neuralnetworks/util/Environment.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/util/Environment.java
@@ -1,6 +1,6 @@
 package com.github.neuralnetworks.util;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.util.KernelExecutionStrategy.CPUKernelExecution;
 import com.github.neuralnetworks.util.KernelExecutionStrategy.DefaultKernelExecution;
 import com.github.neuralnetworks.util.KernelExecutionStrategy.GPUKernelExecution;

--- a/nn-core/src/main/java/com/github/neuralnetworks/util/KernelExecutionStrategy.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/util/KernelExecutionStrategy.java
@@ -1,8 +1,8 @@
 package com.github.neuralnetworks.util;
 
-import com.amd.aparapi.Kernel;
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
-import com.amd.aparapi.Range;
+import com.aparapi.Kernel;
+import com.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Range;
 
 /**
  * Implementations provide execution mode for Aparapi kernel

--- a/nn-core/src/main/java/com/github/neuralnetworks/util/Util.java
+++ b/nn-core/src/main/java/com/github/neuralnetworks/util/Util.java
@@ -114,7 +114,7 @@ public class Util {
      * @return whether there is a bias connection in the list
      */
     public static boolean hasBias(Collection<Connections> connections) {
-	return connections.stream().filter(c -> isBias(c.getInputLayer())).findAny().isPresent();
+	return connections.stream().anyMatch(c -> isBias(c.getInputLayer()));
     }
 
     public static void printMatrix(float[] array, int rows, int columns) {

--- a/nn-core/src/test/java/com/github/neuralnetworks/test/AETest.java
+++ b/nn-core/src/test/java/com/github/neuralnetworks/test/AETest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.types.Autoencoder;
 import com.github.neuralnetworks.architecture.types.NNFactory;
 import com.github.neuralnetworks.input.MultipleNeuronsOutputError;

--- a/nn-core/src/test/java/com/github/neuralnetworks/test/CNNTest.java
+++ b/nn-core/src/test/java/com/github/neuralnetworks/test/CNNTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.ConnectionFactory;
 import com.github.neuralnetworks.architecture.Connections;
 import com.github.neuralnetworks.architecture.Conv2DConnection;

--- a/nn-core/src/test/java/com/github/neuralnetworks/test/FFNNTest.java
+++ b/nn-core/src/test/java/com/github/neuralnetworks/test/FFNNTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.ConnectionFactory;
 import com.github.neuralnetworks.architecture.Connections;
 import com.github.neuralnetworks.architecture.FullyConnected;

--- a/nn-core/src/test/java/com/github/neuralnetworks/test/GeneralTest.java
+++ b/nn-core/src/test/java/com/github/neuralnetworks/test/GeneralTest.java
@@ -10,7 +10,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.ConnectionFactory;
 import com.github.neuralnetworks.architecture.Conv2DConnection;
 import com.github.neuralnetworks.architecture.FullyConnected;

--- a/nn-core/src/test/java/com/github/neuralnetworks/test/RBMTest.java
+++ b/nn-core/src/test/java/com/github/neuralnetworks/test/RBMTest.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.Layer;
 import com.github.neuralnetworks.architecture.types.NNFactory;
 import com.github.neuralnetworks.architecture.types.RBM;

--- a/nn-samples/src/main/java/com/github/neuralnetworks/samples/iris/IrisTargetMultiNeuronOutputConverter.java
+++ b/nn-samples/src/main/java/com/github/neuralnetworks/samples/iris/IrisTargetMultiNeuronOutputConverter.java
@@ -10,6 +10,6 @@ public class IrisTargetMultiNeuronOutputConverter implements InputConverter {
     @Override
     public void convert(Object input, float[] output) {
 	Util.fillArray(output, 0);
-	output[((Integer) input).intValue()] = 1;
+	output[(Integer) input] = 1;
     }
 }

--- a/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/CifarTest.java
+++ b/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/CifarTest.java
@@ -4,7 +4,7 @@ import java.util.Random;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.NeuralNetworkImpl;
 import com.github.neuralnetworks.architecture.types.NNFactory;
 import com.github.neuralnetworks.input.MultipleNeuronsOutputError;

--- a/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/IrisTest.java
+++ b/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/IrisTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.NeuralNetwork;
 import com.github.neuralnetworks.architecture.NeuralNetworkImpl;
 import com.github.neuralnetworks.architecture.types.Autoencoder;

--- a/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/MnistTest.java
+++ b/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/MnistTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.NeuralNetworkImpl;
 import com.github.neuralnetworks.architecture.types.NNFactory;
 import com.github.neuralnetworks.input.MultipleNeuronsOutputError;

--- a/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/XorTest.java
+++ b/nn-samples/src/test/java/com/github/neuralnetworks/samples/test/XorTest.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-import com.amd.aparapi.Kernel.EXECUTION_MODE;
+import com.aparapi.Kernel.EXECUTION_MODE;
 import com.github.neuralnetworks.architecture.FullyConnected;
 import com.github.neuralnetworks.architecture.NeuralNetworkImpl;
 import com.github.neuralnetworks.architecture.types.NNFactory;


### PR DESCRIPTION
Changed `com.amd.aparapi` to `com.aparapi` as per version 1.3.4 of the dependency (downloaded from maven central, and designated the recent release version on [the Aparapi webpage](www.aparapi.com)).
Corrected some code analysis warnings: Malformed JavaDocs, more Java 8 usage, simplification of conditionals, unnecessary boxing, and an inefficient array copy.